### PR TITLE
Feature/linode deployment sal3.10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,12 +113,12 @@ pipeline {
       steps {
         script {
           sshagent(credentials: ['love-ssh-key-2']) {
-            sh 'scp -o StrictHostKeyChecking=no deploy/linode/docker-compose-dev.yml love@dev.love.inria.cl:.'
+            sh 'scp -o StrictHostKeyChecking=no deploy/linode/docker-compose.yml love@dev.love.inria.cl:.'
             sh 'scp -o StrictHostKeyChecking=no deploy/linode/.env love@dev.love.inria.cl:.'
             sh 'scp -o StrictHostKeyChecking=no deploy/ospl.xml love@dev.love.inria.cl:.'
-            sh 'ssh love@dev.love.inria.cl docker-compose -f docker-compose-dev.yml pull'
-            sh 'ssh love@dev.love.inria.cl docker-compose -f docker-compose-dev.yml down -v'
-            sh 'ssh love@dev.love.inria.cl docker-compose -f docker-compose-dev.yml up -d'
+            sh 'ssh love@dev.love.inria.cl docker-compose  pull'
+            sh 'ssh love@dev.love.inria.cl docker-compose  down -v'
+            sh 'ssh love@dev.love.inria.cl docker-compose  up -d'
           }
         }
       }
@@ -137,9 +137,9 @@ pipeline {
           sshagent(credentials: ['love-ssh-key-2']) {
             sh 'scp -o StrictHostKeyChecking=no deploy/linode/docker-compose.yml love@love.inria.cl:.'
             sh 'scp -o StrictHostKeyChecking=no deploy/linode/.env love@love.inria.cl:.'
-            sh 'ssh love@love.inria.cl docker-compose pull'
-            sh 'ssh love@love.inria.cl docker-compose down -v'
-            sh 'ssh love@love.inria.cl docker-compose up -d'
+            sh 'ssh love@love.inria.cl docker-compose -f docker-compose-master.yml pull'
+            sh 'ssh love@love.inria.cl docker-compose -f docker-compose-master.yml down -v'
+            sh 'ssh love@love.inria.cl docker-compose -f docker-compose-master.yml up -d'
           }
         }
       }

--- a/deploy/linode/.env
+++ b/deploy/linode/.env
@@ -1,20 +1,23 @@
+DOCKERFILE_PATH_NGINX=nginx/
+
 LOVE_ROOT_PATH=/home/LOVE/
-LOVE_PRODUCER_WEBSOCKET_HOST=love-nginx/manager/ws/subscription
+LOVE_PRODUCER_WEBSOCKET_HOST=localhost/manager/ws/subscription
 LOVE_MANAGER_LDAP_SERVER_URI=ldap://dev.love.inria.cl:389
-LOVE_MANAGER_REDIS_HOST=redis
+LOVE_MANAGER_REDIS_HOST=localhost
 LOVE_FRONTEND_WEBSOCKET_HOST=localhost
 PROCESS_CONNECTION_PASS=my_dev_password
 
 REDIS_PASS=admin123
 
 NETWORK_NAME=host
-LSST_DDS_DOMAIN=my_test
+LSST_DDS_DOMAIN=atsimulatorcsc
 
 
 # SIMULATOR RELATED VARIABLES
 #----------------------------------
 
-OSPL_CONFIG_PATH=./ospl.xml
+DOCKERFILE_PATH_SIMULATOR=../../../LOVE-simulator/
+OSPL_CONFIG_PATH=../ospl.xml
 OSPL_MOUNT_POINT=/home/saluser/ospl.xml
 OSPL_URI=file:///home/saluser/ospl.xml
 LSST_DDS_DOMAIN=atsimulatorcsc

--- a/deploy/linode/docker-compose-master.yml
+++ b/deploy/linode/docker-compose-master.yml
@@ -1,39 +1,25 @@
 version: "3.4"
 
 services:
-  atdome-sim:
-    image: lsstts/at_dome_sim:v0.6.1_sal3.10_salobj4
-    container_name: atdome-sim-build
-    environment:
-        - OSPL_URI=${OSPL_URI}
-        - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
-    network_mode: ${NETWORK_NAME}
-    volumes:
-        - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
-
-    entrypoint: ["/home/saluser/.setup.sh"]
-
-  simulator:
-    container_name: love-simulator
-    image: inriachile/love-simulator:develop
-    environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
-    network_mode: ${NETWORK_NAME}
-
   producer:
     container_name: love-producer
-    image: inriachile/love-producer:develop
+    image: inriachile/love-producer:master
     environment:
       - WEBSOCKET_HOST=${LOVE_PRODUCER_WEBSOCKET_HOST}
       - PROCESS_CONNECTION_PASS=${PROCESS_CONNECTION_PASS}
       - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
     network_mode: ${NETWORK_NAME}
 
-
+  simulator:
+    container_name: love-simulator
+    image: inriachile/love-simulator:master
+    environment:
+      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+    network_mode: ${NETWORK_NAME}
 
   manager:
     container_name: love-manager
-    image: inriachile/love-manager:develop
+    image: inriachile/love-manager:master
     ports:
       - "8000:8000"
     environment:
@@ -47,7 +33,7 @@ services:
 
   frontend:
     container_name: love-frontend
-    image: inriachile/love-frontend:develop
+    image: inriachile/love-frontend:master
     depends_on:
       - manager
     volumes:
@@ -64,7 +50,7 @@ services:
 
   nginx:
     container_name: love-nginx
-    image: inriachile/love-nginx:develop
+    image: inriachile/love-nginx:master
     restart: always
     depends_on:
       - manager
@@ -75,7 +61,6 @@ services:
       - frontend-volume:/usr/src/love-frontend
       - manager-volume:/usr/src/love-manager
     network_mode: ${NETWORK_NAME}
-
 
 volumes:
   frontend-volume:

--- a/deploy/linode/docker-compose.yml
+++ b/deploy/linode/docker-compose.yml
@@ -67,8 +67,7 @@ services:
 
   nginx:
     container_name: love-nginx
-    image: love-nginx-image
-    build: ${DOCKERFILE_PATH_NGINX}
+    image: inriachile/love-nginx:develop
     restart: always
     depends_on:
       - manager

--- a/deploy/linode/docker-compose.yml
+++ b/deploy/linode/docker-compose.yml
@@ -1,25 +1,42 @@
-version: "3.4"
+version: "3.7"
 
 services:
-  producer:
-    container_name: love-producer
-    image: inriachile/love-producer:master
+  #----- simulators -------
+  atdome-sim:
+    image: lsstts/at_dome_sim:v0.6.1_sal3.10_salobj4
+    container_name: atdome-sim
     environment:
-      - WEBSOCKET_HOST=${LOVE_PRODUCER_WEBSOCKET_HOST}
-      - PROCESS_CONNECTION_PASS=${PROCESS_CONNECTION_PASS}
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+        - OSPL_URI=${OSPL_URI}
+        - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
     network_mode: ${NETWORK_NAME}
+    volumes:
+        - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
+
+    entrypoint: ["/home/saluser/.setup.sh"]
 
   simulator:
     container_name: love-simulator
-    image: inriachile/love-simulator:master
+    image: inriachile/love-simulator:develop
     environment:
       - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+    volumes:
+      - ${DOCKERFILE_PATH_SIMULATOR}:/usr/src/love
+    network_mode: ${NETWORK_NAME}
+  
+
+  #----- LOVE--------------
+  producer:
+    container_name: love-producer
+    image: inriachile/love-producer:develop
+    environment:
+      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - WEBSOCKET_HOST=${LOVE_PRODUCER_WEBSOCKET_HOST}
+      - PROCESS_CONNECTION_PASS=${PROCESS_CONNECTION_PASS}
     network_mode: ${NETWORK_NAME}
 
   manager:
     container_name: love-manager
-    image: inriachile/love-manager:master
+    image: inriachile/love-manager:develop
     ports:
       - "8000:8000"
     environment:
@@ -33,7 +50,7 @@ services:
 
   frontend:
     container_name: love-frontend
-    image: inriachile/love-frontend:master
+    image: inriachile/love-frontend:develop
     depends_on:
       - manager
     volumes:
@@ -50,7 +67,8 @@ services:
 
   nginx:
     container_name: love-nginx
-    image: inriachile/love-nginx:master
+    image: love-nginx-image
+    build: ${DOCKERFILE_PATH_NGINX}
     restart: always
     depends_on:
       - manager


### PR DESCRIPTION
Linode deployment is not working with the new configuration (network=host, sal 3.10). 
Specifically, the `love-producer` shows this error:
```
love-producer | [Errno -2] Name or service not known
love-producer | ### closed ###
love-producer | ### error ###

```
which suggests that it can't find the manager on the network.


Replacing the current `linode-develop` deployment by `local/build` (`.yml`, `.env` and `nginx/`), using `inriachile/*` images fixes it. 

This PR is to trigger the remote build of the `love-nginx:develop` image and test if the deployment runs OK.
