### PR TITLE
Feature/testcsc sim

### DIFF
--- a/deploy/local/build/config/config.json
+++ b/deploy/local/build/config/config.json
@@ -9,9 +9,23 @@
     {
       "index": 1,
       "source": "command_sim"
+    }
+  ],
+  "Test": [
+    {
+      "index":1,
+      "source": "command_sim"
     },
     {
-      "index": 2,
+      "index":2,
+      "source": "command_sim"
+    },
+    {
+      "index":3,
+      "source": "command_sim"
+    },
+    {
+      "index":4,
       "source": "command_sim"
     }
   ]

--- a/deploy/local/build/docker-compose.yml
+++ b/deploy/local/build/docker-compose.yml
@@ -2,6 +2,22 @@ version: "3.7"
 
 services:
   #----- simulators -------
+  testcsc-sim:
+    build:
+      context: ${DOCKERFILE_PATH_SIMULATOR}
+      dockerfile: Dockerfile-testcsc
+    container_name: testcsc-sim-build
+    environment:
+        - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+    volumes:
+        - ./config:/home/saluser/config/
+    network_mode: ${NETWORK_NAME}
+    logging:
+      driver: "json-file"
+      options:
+          max-file: "5"
+          max-size: "10m"
+
   atdome-sim:
     build:
       context: ${DOCKERFILE_PATH_SIMULATOR}

--- a/deploy/local/build/docker-compose.yml
+++ b/deploy/local/build/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     depends_on:
       - scriptqueue-sim
       - atdome-sim
-
+      - testcsc-sim
 
   #----- LOVE--------------
   producer:

--- a/deploy/local/live/config/config.json
+++ b/deploy/local/live/config/config.json
@@ -9,9 +9,23 @@
     {
       "index": 1,
       "source": "command_sim"
+    }
+  ],
+  "Test": [
+    {
+      "index":1,
+      "source": "command_sim"
     },
     {
-      "index": 2,
+      "index":2,
+      "source": "command_sim"
+    },
+    {
+      "index":3,
+      "source": "command_sim"
+    },
+    {
+      "index":4,
       "source": "command_sim"
     }
   ]

--- a/deploy/local/live/docker-compose.yml
+++ b/deploy/local/live/docker-compose.yml
@@ -2,6 +2,22 @@ version: "3.7"
 
 services:
   #----- simulators -------
+  testcsc-sim:
+    build:
+      context: ${DOCKERFILE_PATH_SIMULATOR}
+      dockerfile: Dockerfile-testcsc
+    container_name: testcsc-sim-build
+    environment:
+        - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+    volumes:
+        - ./config:/home/saluser/config/
+    network_mode: ${NETWORK_NAME}
+    logging:
+      driver: "json-file"
+      options:
+          max-file: "5"
+          max-size: "10m"
+
   atdome-sim:
     build:
       context: ${DOCKERFILE_PATH_SIMULATOR}
@@ -57,6 +73,7 @@ services:
     depends_on:
       - scriptqueue-sim
       - atdome-sim
+      - testcsc-sim
 
 
   #----- LOVE--------------


### PR DESCRIPTION
Adds a service to the `local/build` and `local/live` `docker-compose.yml` files to launch the Controller `Test` CSC according to the `config.json`, as mentioned in https://github.com/lsst-ts/LOVE-simulator/pull/18.

