### PR TITLE
Change simulator mounting point in live env to enable docs building

### DIFF
--- a/deploy/local/live/docker-compose.yml
+++ b/deploy/local/live/docker-compose.yml
@@ -62,8 +62,7 @@ services:
     environment:
       - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
     volumes:
-      - ${DOCKERFILE_PATH_SIMULATOR}/simulator:/usr/src/love/simulator
-      - ./config:/usr/src/love/config/
+      - ${DOCKERFILE_PATH_SIMULATOR}:/usr/src/love
     network_mode: ${NETWORK_NAME}
     logging:
       driver: "json-file"


### PR DESCRIPTION
This version contains the following deployment environments:

- La Serena
- Tucson
- Linode:
  - develop
  - master
- Local:
  - live
  - build

---
Changes to the last release (0.2.x)
Change simulator mounting point in live env to enable docs building