### PR TITLE
Feature/improve deployment

### DIFF
--- a/deploy/linode/.env
+++ b/deploy/linode/.env
@@ -5,9 +5,8 @@
 
 
 # INTERACTION BETWEEN SERVICES
+SERVER_URL=.love.inria.cl
 LOVE_PRODUCER_WEBSOCKET_HOST=love-nginx/manager/ws/subscription
-PROCESS_CONNECTION_PASS=my_dev_password
-LOVE_FRONTEND_WEBSOCKET_HOST=localhost
 
 # LSST CONFIG
 NETWORK_NAME=testnet
@@ -25,7 +24,9 @@ DB_NAME=postgres
 DB_USER=postgres
 DB_HOST=love-database
 DB_PORT=5432
+
 ## (Dummy) secrets, make sure to reset them in real production environments!
+# PROCESS_CONNECTION_PASS=my_dev_password
 #REDIS_PASS=admin123
 #DB_PASS=postgres
 #ADMIN_USER_PASS=test

--- a/deploy/linode/docker-compose-master.yml
+++ b/deploy/linode/docker-compose-master.yml
@@ -288,6 +288,7 @@ services:
       - redis
       - database
     environment:
+      - SERVER_URL=${SERVER_URL}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PASS=${REDIS_PASS}
       - AUTH_LDAP_SERVER_URI=${LOVE_MANAGER_LDAP_SERVER_URI}

--- a/deploy/linode/docker-compose.yml
+++ b/deploy/linode/docker-compose.yml
@@ -288,6 +288,7 @@ services:
       - redis
       - database
     environment:
+      - SERVER_URL=${SERVER_URL}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PASS=${REDIS_PASS}
       - AUTH_LDAP_SERVER_URI=${LOVE_MANAGER_LDAP_SERVER_URI}

--- a/deploy/local/build/.env
+++ b/deploy/local/build/.env
@@ -10,9 +10,8 @@ JUPYTER_PATH=../../../jupyter
 JUPYTER_PASS=jupyter
 
 # INTERACTION BETWEEN SERVICES
+SERVER_URL=*
 LOVE_PRODUCER_WEBSOCKET_HOST=love-nginx/manager/ws/subscription
-PROCESS_CONNECTION_PASS=my_dev_password
-LOVE_FRONTEND_WEBSOCKET_HOST=localhost
 
 # LSST CONFIG
 NETWORK_NAME=testnet
@@ -26,7 +25,9 @@ DB_NAME=postgres
 DB_USER=postgres
 DB_HOST=love-database
 DB_PORT=5432
+
 ## (Dummy) secrets, make sure to reset them in real production environments!
+PROCESS_CONNECTION_PASS=my_dev_password
 REDIS_PASS=admin123
 DB_PASS=postgres
 ADMIN_USER_PASS=test

--- a/deploy/local/build/docker-compose.yml
+++ b/deploy/local/build/docker-compose.yml
@@ -21,16 +21,16 @@ services:
       dockerfile: Dockerfile-testcsc
     container_name: testcsc-sim-build
     environment:
-        - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
     network_mode: ${NETWORK_NAME}
     restart: always
     volumes:
-        - ./config:/home/saluser/config/
+      - ./config:/home/saluser/config/
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   atdome-sim:
     build:
@@ -39,18 +39,18 @@ services:
     container_name: atdome-sim-build
     entrypoint: ["/home/saluser/atdome-setup.sh"]
     environment:
-        - OSPL_URI=${OSPL_URI}
-        - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - OSPL_URI=${OSPL_URI}
+      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
     network_mode: ${NETWORK_NAME}
     restart: always
     volumes:
-        - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
-        - ./config:/home/saluser/config/
+      - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
+      - ./config:/home/saluser/config/
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   atmcs-sim:
     build:
@@ -58,18 +58,18 @@ services:
       dockerfile: Dockerfile-atmcs
     container_name: atmcs-sim-build
     environment:
-        - OSPL_URI=${OSPL_URI}
-        - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - OSPL_URI=${OSPL_URI}
+      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
     network_mode: ${NETWORK_NAME}
     volumes:
-        - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
-        - ./config:/home/saluser/config/
+      - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
+      - ./config:/home/saluser/config/
     entrypoint: ["/home/saluser/atmcs-setup.sh"]
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   scriptqueue-sim:
     build:
@@ -77,16 +77,16 @@ services:
       dockerfile: Dockerfile-scriptqueue
     container_name: scriptqueue-sim-build
     environment:
-        - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
     network_mode: ${NETWORK_NAME}
     restart: always
     volumes:
-        - ./config:/home/saluser/config/
+      - ./config:/home/saluser/config/
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   watcher-sim:
     build:
@@ -95,18 +95,18 @@ services:
     container_name: watcher-sim-build
     entrypoint: ["/home/saluser/watcher-setup.sh"]
     environment:
-        - OSPL_URI=${OSPL_URI}
-        - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+      - OSPL_URI=${OSPL_URI}
+      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
     network_mode: ${NETWORK_NAME}
     restart: always
     volumes:
-        - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
-        - ./config:/home/saluser/config/
+      - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
+      - ./config:/home/saluser/config/
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   gencam-sim:
     image: lsstts/gencam:latest
@@ -146,8 +146,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   #----- LOVE PRODUCER --------------
   events:
@@ -168,8 +168,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   telemetries:
     container_name: love-telemetries-producer
@@ -189,8 +189,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   scriptqueue:
     container_name: love-scriptqueue-producer
@@ -210,8 +210,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   heartbeats:
     container_name: love-heartbeats-producer
@@ -231,8 +231,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   #-----LOVE COMMANDER -----------
 
@@ -250,7 +250,7 @@ services:
       driver: "json-file"
       options:
         max-file: "5"
-        max-size: "10m"    
+        max-size: "10m"
 
   #----- LOVE MANAGER --------------
   redis:
@@ -264,8 +264,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   database:
     container_name: love-database
@@ -281,8 +281,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   manager:
     container_name: love-manager
@@ -295,6 +295,7 @@ services:
       - database
       - commander
     environment:
+      - SERVER_URL=${SERVER_URL}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PASS=${REDIS_PASS}
       - AUTH_LDAP_SERVER_URI=${LOVE_MANAGER_LDAP_SERVER_URI}
@@ -320,16 +321,14 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   #----- LOVE FRONTEND --------------
   frontend:
     container_name: love-frontend
     build:
       context: ${DOCKERFILE_PATH_FRONTEND}
-      args:
-        WEBSOCKET_HOST: ${LOVE_FRONTEND_WEBSOCKET_HOST}
       dockerfile: Dockerfile
     image: love-frontend-image
     depends_on:
@@ -340,8 +339,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
     tty: true
 
   nginx:
@@ -363,8 +362,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
 volumes:
   frontend-volume:

--- a/deploy/local/live/.env
+++ b/deploy/local/live/.env
@@ -5,14 +5,13 @@ DOCKERFILE_PATH_MANAGER=../../../../LOVE-manager/
 DOCKERFILE_PATH_SIMULATOR=../../../../LOVE-simulator/
 DOCKERFILE_PATH_COMMANDER=../../../../LOVE-commander/
 
+# INTERACTION BETWEEN SERVICES
+SERVER_URL=*
+LOVE_PRODUCER_WEBSOCKET_HOST=love-nginx-mount/manager/ws/subscription
+
 # JUPYTER notebooks
 JUPYTER_PATH=../../../jupyter
 JUPYTER_PASS=jupyter
-
-# INTERACTION BETWEEN SERVICES
-LOVE_PRODUCER_WEBSOCKET_HOST=love-nginx-mount/manager/ws/subscription
-PROCESS_CONNECTION_PASS=my_dev_password
-LOVE_FRONTEND_WEBSOCKET_HOST=localhost
 
 # LSST CONFIG
 NETWORK_NAME=testnet
@@ -28,6 +27,7 @@ DB_HOST=love-database
 DB_PORT=5432
 
 ## (Dummy) secrets, make sure to reset them in real production environments!
+PROCESS_CONNECTION_PASS=my_dev_password
 REDIS_PASS=admin123
 DB_PASS=postgres
 ADMIN_USER_PASS=test

--- a/deploy/local/live/docker-compose.yml
+++ b/deploy/local/live/docker-compose.yml
@@ -291,7 +291,7 @@ services:
     depends_on:
       - nginx
   #----- LOVE MANAGER --------------
-  
+
   redis:
     container_name: redis
     image: redis:5.0.3
@@ -334,6 +334,7 @@ services:
       - database
       - commander
     environment:
+      - SERVER_URL=${SERVER_URL}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PASS=${REDIS_PASS}
       - AUTH_LDAP_SERVER_URI=${LOVE_MANAGER_LDAP_SERVER_URI}
@@ -367,8 +368,6 @@ services:
     container_name: love-frontend-mount
     build:
       context: ${DOCKERFILE_PATH_FRONTEND}
-      args:
-        WEBSOCKET_HOST: ${LOVE_FRONTEND_WEBSOCKET_HOST}
       dockerfile: Dockerfile-dev
     image: love-frontend-image-mount
     depends_on:

--- a/deploy/summit/.env
+++ b/deploy/summit/.env
@@ -1,6 +1,5 @@
 # INTERACTION BETWEEN SERVICES
 LOVE_PRODUCER_WEBSOCKET_HOST=love-nginx/manager/ws/subscription
-PROCESS_CONNECTION_PASS=my_dev_password
 
 # LSST CONFIG
 LSST_DDS_DOMAIN=lsatmcs
@@ -16,6 +15,7 @@ DB_HOST=love-database
 DB_PORT=5432
 
 ## (Dummy) secrets, make sure to reset them in real production environments!
+# PROCESS_CONNECTION_PASS=real_password
 # REDIS_PASS=admin123
 # DB_PASS=postgres
 # ADMIN_USER_PASS

--- a/deploy/summit/docker-compose.yml
+++ b/deploy/summit/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       - database
       - commander
     environment:
+      - SERVER_URL=${SERVER_URL}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PASS=${REDIS_PASS}
       - AUTH_LDAP_SERVER_URI=${LOVE_MANAGER_LDAP_SERVER_URI}
@@ -124,8 +125,8 @@ services:
       - "8000:8000"
     restart: always
     volumes:
-        - manager-static:/usr/src/love/manager
-        - ./media:/usr/src/love/manager/media
+      - manager-static:/usr/src/love/manager
+      - ./media:/usr/src/love/manager/media
 
   #----- LOVE FRONTEND --------------
   frontend:

--- a/deploy/tucson/.env
+++ b/deploy/tucson/.env
@@ -1,7 +1,5 @@
 # INTERACTION BETWEEN SERVICES
 LOVE_PRODUCER_WEBSOCKET_HOST=love-nginx/manager/ws/subscription
-PROCESS_CONNECTION_PASS=my_dev_password
-LOVE_FRONTEND_WEBSOCKET_HOST=localhost
 
 # LSST CONFIG
 NETWORK_NAME=lab-priv-network
@@ -18,6 +16,7 @@ DB_HOST=love-database
 DB_PORT=5432
 
 ## (Dummy) secrets, make sure to reset them in real production environments!
+# PROCESS_CONNECTION_PASS=real_password
 # REDIS_PASS=admin123
 # DB_PASS=postgres
 # ADMIN_USER_PASS

--- a/deploy/tucson/docker-compose.yml
+++ b/deploy/tucson/docker-compose.yml
@@ -18,8 +18,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   #----- LOVE MANAGER --------------
   redis:
@@ -35,8 +35,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   database:
     container_name: love-database
@@ -54,8 +54,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   manager:
     container_name: love-manager
@@ -64,6 +64,7 @@ services:
       - redis
       - database
     environment:
+      - SERVER_URL=${SERVER_URL}
       - REDIS_HOST=${REDIS_HOST}
       - REDIS_PORT=${REDIS_PORT}
       - REDIS_PASS=${REDIS_PASS}
@@ -90,8 +91,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
   #----- LOVE FRONTEND --------------
   frontend:
@@ -104,9 +105,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
-
+        max-file: "5"
+        max-size: "10m"
 
   nginx:
     container_name: love-nginx
@@ -128,8 +128,8 @@ services:
     logging:
       driver: "json-file"
       options:
-          max-file: "5"
-          max-size: "10m"
+        max-file: "5"
+        max-size: "10m"
 
 volumes:
   frontend-volume:


### PR DESCRIPTION
- Comment environment variable `PROCESS_CONNECTION_PASS` from real environments. **Now it needs to be defined in each production server!**
- Remove unused `LOVE_FRONTEND_WEBSOCKET_HOST` environment variable
- Add `SERVER_URL` environment variable to all envs. It specifies the URL where the system should be accessible to external connections
- Pass the `SERVER_URL` environment variable LOVE-manager, to be added to its `ALLOWED_HOSTS` setting

Notes:
- For local deployments (build and live environments) we use `SERVER_URL=*`, in order to allow connections from other devices (e.g. smartphones, tablets, etc) for development purposes. This MUST NOT be used for any real production environments
- For the linode environments we use `SERVER_URL=.love.inria.cl`, in order to match both: `love.inria.cl` and `dev.love.inria.cl`