### PR TITLE
Add styleguidist to live and lite envs

### DIFF
--- a/deploy/local/lite/docker-compose.yml
+++ b/deploy/local/lite/docker-compose.yml
@@ -10,6 +10,24 @@ services:
     # network_mode: ${NETWORK_NAME}
     ports:
       - "3000:3000"
+    volumes:
+      - ${DOCKERFILE_PATH_FRONTEND}:/usr/src/love
+      - /usr/src/love/love/node_modules
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
+
+  styleguide:
+    container_name: love-styleguide-mount
+    build:
+      context: ${DOCKERFILE_PATH_FRONTEND}
+      dockerfile: Dockerfile-dev
+    image: love-frontend-image-mount
+    command: yarn guide:start
+    # network_mode: ${NETWORK_NAME}
+    ports:
       - "3001:3001"
     volumes:
       - ${DOCKERFILE_PATH_FRONTEND}:/usr/src/love

--- a/deploy/local/live/docker-compose.yml
+++ b/deploy/local/live/docker-compose.yml
@@ -376,6 +376,24 @@ services:
     network_mode: ${NETWORK_NAME}
     ports:
       - "3000:3000"
+    volumes:
+      - ${DOCKERFILE_PATH_FRONTEND}:/usr/src/love
+      - /usr/src/love/love/node_modules
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
+
+  styleguide:
+    container_name: love-styleguide-mount
+    build:
+      context: ${DOCKERFILE_PATH_FRONTEND}
+      dockerfile: Dockerfile-dev
+    image: love-frontend-image-mount
+    command: yarn guide:start --disable-host-check
+    network_mode: ${NETWORK_NAME}
+    ports:
       - "3001:3001"
     volumes:
       - ${DOCKERFILE_PATH_FRONTEND}:/usr/src/love
@@ -392,6 +410,7 @@ services:
     depends_on:
       - manager
       - frontend
+      # - styleguide
       - gencam-sim
       - commander
     network_mode: ${NETWORK_NAME}

--- a/deploy/local/live/nginx.conf
+++ b/deploy/local/live/nginx.conf
@@ -14,9 +14,9 @@ server {
         proxy_redirect off;
     }
 
-    location /styleguide {
-        proxy_pass http://love-frontend-mount:3001;
-    }
+    # location /styleguide {
+    #     proxy_pass http://love-styleguide-mount:3001;
+    # }
 
     location /gencam {
         proxy_pass http://gencam-sim:5013;


### PR DESCRIPTION
- Add styleguidist service to live and lite envs
- Integration with nginx does not work for now, but we can access it in `localhost:3001`