### PR TITLE
Use ts_*scripts  and disable simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ webpack-stats.*
 **/__snapshots__/*
 **/__image_snapshots__/*
 **/*.log
+**/ts_externalscripts
+**/ts_standardscripts

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
       steps {
         script {
           sshagent(credentials: ['love-ssh-key-2']) {
+            sh 'scp -o StrictHostKeyChecking=no deploy/linode/run.sh love@dev.love.inria.cl:.'
             sh 'scp -o StrictHostKeyChecking=no deploy/linode/docker-compose.yml love@dev.love.inria.cl:.'
             sh 'scp -o StrictHostKeyChecking=no deploy/linode/.env love@dev.love.inria.cl:.'
             sh 'scp -o StrictHostKeyChecking=no deploy/linode/ospl.xml love@dev.love.inria.cl:.'
@@ -30,10 +31,8 @@ pipeline {
             sh 'scp -o StrictHostKeyChecking=no -r deploy/linode/config love@dev.love.inria.cl:.'
             sh 'scp -o StrictHostKeyChecking=no -r deploy/linode/simulatorcamera.py love@dev.love.inria.cl:.'
             sh 'scp -o StrictHostKeyChecking=no -r jupyter love@dev.love.inria.cl:.'
-            sh 'ssh love@dev.love.inria.cl "docker network inspect testnet >/dev/null 2>&1 || docker network create testnet"'
-            sh 'ssh love@dev.love.inria.cl docker-compose pull'
-            sh 'ssh love@dev.love.inria.cl docker-compose down -v'
-            sh 'ssh love@dev.love.inria.cl "source local_env.sh; docker-compose up -d"'
+            sh 'scp -o StrictHostKeyChecking=no -r jupyter love@dev.love.inria.cl:.'
+            sh 'ssh love@dev.love.inria.cl "./run.sh'
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ The LOVE repositories are expected to be at the same level under the same parent
   - LOVE-producer
   - LOVE-integration-tools
   - LOVE-simulator
-
+  - ts_standardscripts (for `linode` and `local/live` environments only)
+  - ts_externalscripts (for `linode` and `local/live` environments only)
 ---
+
 
 ## Content
 

--- a/deploy/linode/.env
+++ b/deploy/linode/.env
@@ -40,3 +40,8 @@ OSPL_CONFIG_PATH=./ospl.xml
 OSPL_MOUNT_POINT=/home/saluser/ospl.xml
 OSPL_URI=file:///home/saluser/ospl.xml
 LSST_EFD_HOST=139.229.162.118
+
+
+# ts_scripts required for scriptqueue-sim
+TS_STANDARDSCRIPTS=./ts_standardscripts/scripts
+TS_EXTERNALSCRIPTS=./ts_externalscripts/scripts

--- a/deploy/linode/docker-compose.yml
+++ b/deploy/linode/docker-compose.yml
@@ -122,26 +122,26 @@ services:
         max-size: "10m"
     ports:
       - 5013:5013
-  simulator:
-    container_name: love-simulator
-    image: lsstts/love-simulator:develop
-    depends_on:
-      - scriptqueue-sim
-      - atdome-sim
-      - testcsc-sim
-      - gencam-sim
-      - atmcs-sim
-    environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
-    network_mode: ${NETWORK_NAME}
-    restart: always
-    volumes:
-      - ./config:/usr/src/love/config/
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "5"
-        max-size: "10m"
+  # simulator:
+  #   container_name: love-simulator
+  #   image: lsstts/love-simulator:develop
+  #   depends_on:
+  #     - scriptqueue-sim
+  #     - atdome-sim
+  #     - testcsc-sim
+  #     - gencam-sim
+  #     - atmcs-sim
+  #   environment:
+  #     - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+  #   network_mode: ${NETWORK_NAME}
+  #   restart: always
+  #   volumes:
+  #     - ./config:/usr/src/love/config/
+  #   logging:
+  #     driver: "json-file"
+  #     options:
+  #       max-file: "5"
+  #       max-size: "10m"
 
   jupyter:
     container_name: love-jupyter

--- a/deploy/linode/run.sh
+++ b/deploy/linode/run.sh
@@ -1,0 +1,14 @@
+# Create docker network
+docker network inspect testnet >/dev/null 2>&1 || docker network create testnet
+docker network inspect testnet >/dev/null 2>&1 || docker network create testnet
+
+# update ts repos needed
+rm -rf ts_externalscripts
+rm -rf ts_externalscripts
+git clone --depth 1 git@github.com:lsst-ts/ts_standardscripts.git
+git clone --depth 1 git@github.com:lsst-ts/ts_externalscripts.git
+
+# update and restart the LOVE
+docker-compose pull
+docker-compose down -v
+source local_env.sh; docker-compose up -d

--- a/deploy/local/live/.env
+++ b/deploy/local/live/.env
@@ -42,6 +42,6 @@ OSPL_URI=file:///home/saluser/ospl.xml
 LSST_EFD_HOST=139.229.162.118
 
 
-# ts_scripts
+# ts_scripts required for scriptqueue-sim
 TS_STANDARDSCRIPTS=../../../../ts_standardscripts/scripts
 TS_EXTERNALSCRIPTS=../../../../ts_externalscripts/scripts

--- a/deploy/local/live/.env
+++ b/deploy/local/live/.env
@@ -40,3 +40,8 @@ OSPL_CONFIG_PATH=../../linode/ospl.xml
 OSPL_MOUNT_POINT=/home/saluser/ospl.xml
 OSPL_URI=file:///home/saluser/ospl.xml
 LSST_EFD_HOST=139.229.162.118
+
+
+# ts_scripts
+TS_STANDARDSCRIPTS=../../../../ts_standardscripts/scripts
+TS_EXTERNALSCRIPTS=../../../../ts_externalscripts/scripts

--- a/deploy/local/live/docker-compose.yml
+++ b/deploy/local/live/docker-compose.yml
@@ -87,6 +87,8 @@ services:
     restart: always
     volumes:
       - ./config:/home/saluser/config/
+      - ${TS_STANDARDSCRIPTS}:/home/saluser/repos/ts_scriptqueue/tests/data/standard/
+      - ${TS_EXTERNALSCRIPTS}:/home/saluser/repos/ts_scriptqueue/tests/data/external/
     logging:
       driver: "json-file"
       options:
@@ -152,30 +154,30 @@ services:
         max-file: "5"
         max-size: "10m"
 
-  simulator:
-    container_name: love-simulator-mount
-    build:
-      context: ${DOCKERFILE_PATH_SIMULATOR}
-      dockerfile: Dockerfile-dev
-    image: love-simulator-image-mount
-    depends_on:
-      - scriptqueue-sim
-      - atdome-sim
-      - testcsc-sim
-      - gencam-sim
-      - environment-sim
-    environment:
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
-    network_mode: ${NETWORK_NAME}
-    restart: always
-    volumes:
-      - ${DOCKERFILE_PATH_SIMULATOR}:/usr/src/love/
-      - ./config:/usr/src/love/config/
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "5"
-        max-size: "10m"
+  # simulator:
+  #   container_name: love-simulator-mount
+  #   build:
+  #     context: ${DOCKERFILE_PATH_SIMULATOR}
+  #     dockerfile: Dockerfile-dev
+  #   image: love-simulator-image-mount
+  #   depends_on:
+  #     - scriptqueue-sim
+  #     - atdome-sim
+  #     - testcsc-sim
+  #     - gencam-sim
+  #     - environment-sim
+  #   environment:
+  #     - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+  #   network_mode: ${NETWORK_NAME}
+  #   restart: always
+  #   volumes:
+  #     - ${DOCKERFILE_PATH_SIMULATOR}:/usr/src/love/
+  #     - ./config:/usr/src/love/config/
+  #   logging:
+  #     driver: "json-file"
+  #     options:
+  #       max-file: "5"
+  #       max-size: "10m"
 
   jupyter:
     container_name: love-jupyter
@@ -433,7 +435,7 @@ services:
       - frontend
       # - styleguide
       - gencam-sim
-      - commander
+      # - commander
     network_mode: ${NETWORK_NAME}
     ports:
       - "80:80"


### PR DESCRIPTION
Refactors live and linode environments to load ts_externalscripts and ts_standardscripts to use them from the ScriptQueue frontend component. The idea is to move in this direction instead of running simulated commands with the LOVE-simulator. LOVE-simulator is still needed to initialize the "`csc-sim`s".