### PR TITLE
Add deployment at NCSA.

### DIFF
--- a/deploy/ncsa/.env
+++ b/deploy/ncsa/.env
@@ -1,8 +1,13 @@
 # INTERACTION BETWEEN SERVICES
 LOVE_PRODUCER_WEBSOCKET_HOST=love-nginx/manager/ws/subscription
 
+#
+# Vera Rubin build cycle
+#
+cycle=c0014
+
 # LSST CONFIG
-LSST_DDS_DOMAIN=lsatmcs
+LSST_DDS_PARTITION_PREFIX=ncsa
 
 # MANAGER SETTINGS
 # LOVE_MANAGER_LDAP_SERVER_URI=ldap://dev.love.inria.cl:389

--- a/deploy/ncsa/Readme.md
+++ b/deploy/ncsa/Readme.md
@@ -1,0 +1,52 @@
+# Deployment In La Serena
+
+## 1. Prepare deployment
+### 1.1. Copy required files
+Copy the docker-compose and configuration files to the machine <USER>@<SERVER>:
+
+```bash
+scp deploy/laserena/docker-compose.yml <USER>@<SERVER>:.
+scp deploy/laserena/.env <USER>@<SERVER>:.
+scp deploy/laserena/nginx.conf <USER>@<SERVER>:.
+scp deploy/laserena/ospl.xml <USER>@<SERVER>:.
+scp deploy/laserena/config <USER>@<SERVER>:.
+```
+
+### 1.2. (Optional) Change services versions
+In order to modify the version of a service edit the version of the desired service on the corresponding docker-compose file, on the `image` section.
+
+For example, to run the `frontend` service's version `x.y.z`, change the image tag from `master` to `x.y.z`, as following:
+```yaml
+frontend:
+  ...
+  image: inriachile/love-frontend:master
+  ...
+```
+
+into
+
+```yaml
+frontend:
+  ...
+  image: inriachile/love-frontend:x.y.z
+  ...
+```
+
+
+## 2. Launch services
+### 2.1 Launch LOVE services
+```bashM
+ssh <USER>@<SERVER>:.
+source local_env.sh
+docker-compose pull
+docker-compose down -v
+docker-compose up -d
+```
+
+### 2.2. (Optional) Launch Simulators
+```bash
+ssh <USER>@<SERVER>:.
+docker-compose -f docker-compose-simulator.yml pull
+docker-compose -f docker-compose-simulator.yml down -v
+docker-compose -f docker-compose-simulator.yml up -d
+```

--- a/deploy/ncsa/config/config.json
+++ b/deploy/ncsa/config/config.json
@@ -1,0 +1,8 @@
+{
+  "ScriptQueue": [
+    { "index": 1, "source": "" },
+    { "index": 2, "source": "" }
+  ],
+  "Watcher": [{ "index": 0, "source": "" }],
+  "LOVE": [{ "index": 0, "source": "" }]
+}

--- a/deploy/ncsa/config/love.json
+++ b/deploy/ncsa/config/love.json
@@ -1,0 +1,10 @@
+{
+  "alarms": {
+    "minSeveritySound": "serious",
+    "minSeverityNotification": "warning"
+  },
+  "camFeeds": {
+    "generic": "/gencam",
+    "allSky": "/gencam"
+  }
+}

--- a/deploy/ncsa/docker-compose.yml
+++ b/deploy/ncsa/docker-compose.yml
@@ -1,0 +1,186 @@
+# available ips
+# 141.142.238.101
+# 141.142.238.102
+# 141.142.238.103
+# 141.142.238.104
+# 141.142.238.105
+
+x-service: &service
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: "10m"
+
+version: "3.7"
+
+services:
+  love-csc:
+    <<: *service
+    container_name: love-csc
+    image: ts-dockerhub.lsst.org/love-csc:${cycle}
+    environment:
+      - LSST_DDS_PARTITION_PREFIX=${LSST_DDS_PARTITION_PREFIX}
+      - WEBSOCKET_HOST=${LOVE_PRODUCER_WEBSOCKET_HOST}
+      - PROCESS_CONNECTION_PASS=${PROCESS_CONNECTION_PASS}
+    ipc: host
+    pid: host
+    networks:
+      test-stand-network:
+        ipv4_address: "141.142.238.101"
+      love:
+    depends_on:
+      - nginx
+    volumes:
+      - /tmp/docker_tmp/:/tmp/
+      - ./ospl.xml:/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux/etc/config/ospl.xml
+  #----- LOVE PRODUCER --------------
+  producer:
+    <<: *service
+    container_name: love-producer
+    image: ts-dockerhub.lsst.org/love-producer:${cycle}
+    environment:
+      - LSST_DDS_PARTITION_PREFIX=${LSST_DDS_PARTITION_PREFIX}
+      - WEBSOCKET_HOST=${LOVE_PRODUCER_WEBSOCKET_HOST}
+      - PROCESS_CONNECTION_PASS=${PROCESS_CONNECTION_PASS}
+    ipc: host
+    pid: host
+    networks:
+      test-stand-network:
+        ipv4_address: "141.142.238.102"
+      love:
+    restart: always
+    volumes:
+      - /tmp/docker_tmp/:/tmp/
+      - ./config:/usr/src/love/producer/config/
+      - ./ospl.xml:/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux/etc/config/ospl.xml
+
+  #-----LOVE COMMANDER -----------
+  commander:
+    container_name: love-commander
+    image: ts-dockerhub.lsst.org/love-commander:${cycle}
+    environment:
+      - LSST_DDS_PARTITION_PREFIX=${LSST_DDS_PARTITION_PREFIX}
+    ipc: host
+    pid: host
+    networks:
+      test-stand-network:
+        ipv4_address: "141.142.238.103"
+      love:
+    restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
+    volumes:
+      - /tmp/docker_tmp/:/tmp/
+      - ./ospl.xml:/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux/etc/config/ospl.xml
+
+  # #----- LOVE MANAGER --------------
+  redis:
+    <<: *service
+    container_name: redis
+    image: redis:5.0.3
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASS}
+    networks:
+      - love
+    ports:
+      - "6379:6379"
+    restart: always
+
+  database:
+    <<: *service
+    container_name: love-database
+    image: postgres:12.0
+    environment:
+      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASS}
+    networks:
+      - love
+    restart: always
+    volumes:
+      - ./db_data:/var/lib/postgresql/data
+
+  manager:
+    <<: *service
+    container_name: love-manager
+    image: lsstts/love-manager:develop
+    depends_on:
+      - redis
+      - database
+      - commander
+    environment:
+      - SERVER_URL=${SERVER_URL}
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PASS=${REDIS_PASS}
+      - AUTH_LDAP_SERVER_URI=${LOVE_MANAGER_LDAP_SERVER_URI}
+      - PROCESS_CONNECTION_PASS=${PROCESS_CONNECTION_PASS}
+      - ADMIN_USER_PASS=${ADMIN_USER_PASS}
+      - USER_USER_PASS=${USER_USER_PASS}
+      - CMD_USER_PASS=${CMD_USER_PASS}
+      - DB_ENGINE=${DB_ENGINE}
+      - DB_NAME=${DB_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASS=${DB_PASS}
+      - DB_HOST=${DB_HOST}
+      - DB_PORT=${DB_PORT}
+      - COMMANDER_HOSTNAME=love-commander
+      - COMMANDER_PORT=5000
+    networks:
+      - love
+    ports:
+      - "8000:8000"
+    restart: always
+    volumes:
+      - manager-static:/usr/src/love/manager
+      - ./config:/usr/src/love/manager/config
+      - ./media:/usr/src/love/manager/media
+
+  #----- LOVE FRONTEND --------------
+  frontend:
+    <<: *service
+    container_name: love-frontend
+    image: lsstts/love-frontend:develop
+    # depends_on:
+    #   - manager
+    volumes:
+      - frontend-volume:/usr/src/love
+    tty: true
+    networks:
+      - love
+
+  nginx:
+    <<: *service
+    container_name: love-nginx
+    image: nginx:1.13.1
+    depends_on:
+      - manager
+      - frontend
+    # networks:
+    #   control-network:
+    #     ipv4_address: "139.229.167.196"
+    networks:
+      - love
+    ports:
+      - 80:80
+    restart: always
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      - frontend-volume:/usr/src/love-frontend
+      - manager-static:/usr/src/love-manager/static
+      - ./media:/usr/src/love-manager/media
+
+volumes:
+  frontend-volume:
+  manager-static:
+
+networks:
+  default:
+    external:
+      name: test-stand-network
+  test-stand-network:
+    external: true
+  love:
+    external: true

--- a/deploy/ncsa/nginx.conf
+++ b/deploy/ncsa/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        root   /usr/src/love-frontend;
+        try_files $uri$args $uri$args/ $uri/ /index.html;
+    }
+
+    location /manager {
+        proxy_pass http://love-manager:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+
+    location /manager/static {
+        alias /usr/src/love-manager/static;
+    }
+
+    location /manager/media {
+        alias /usr/src/love-manager/media;
+    }
+
+}

--- a/deploy/ncsa/ospl.xml
+++ b/deploy/ncsa/ospl.xml
@@ -1,0 +1,66 @@
+<OpenSplice>
+   <Domain>
+      <Name>ospl_sp_ddsi</Name>
+      <Id>2</Id>
+      <Description>Federated deployment using shared-memory and standard DDSI networking.</Description>
+      <Database>
+         <Size>104857600</Size>
+      </Database>
+      <Service name="ddsi2">
+         <Command>ddsi2</Command>
+      </Service>
+      <Service name="durability">
+         <Command>durability</Command>
+      </Service>
+      <Service name="cmsoap">
+         <Command>cmsoap</Command>
+      </Service>
+   </Domain>
+   <DDSI2Service name="ddsi2">
+      <General>
+         <NetworkInterfaceAddress>AUTO</NetworkInterfaceAddress>
+         <AllowMulticast>true</AllowMulticast>
+         <EnableMulticastLoopback>true</EnableMulticastLoopback>
+         <CoexistWithNativeNetworking>false</CoexistWithNativeNetworking>
+      </General>
+      <Compatibility>
+<!-- see the release notes and/or the OpenSplice configurator on DDSI interoperability -->
+         <StandardsConformance>lax</StandardsConformance>
+<!-- the following one is necessary only for TwinOaks CoreDX DDS compatibility -->
+<!-- <ExplicitlyPublishQosSetToDefault>true</ExplicitlyPublishQosSetToDefault> -->
+      </Compatibility>
+      <Discovery>
+         <ParticipantIndex>none</ParticipantIndex>
+      </Discovery>
+    </DDSI2Service>
+   <DurabilityService name="durability">
+      <ClientDurability enabled="true"/>
+      <Network>
+         <Alignment>
+            <TimeAlignment>false</TimeAlignment>
+            <RequestCombinePeriod>
+               <Initial>2.5</Initial>
+               <Operational>0.1</Operational>
+            </RequestCombinePeriod>
+         </Alignment>
+         <WaitForAttachment maxWaitCount="100">
+            <ServiceName>ddsi2</ServiceName>
+         </WaitForAttachment>
+      </Network>
+      <NameSpaces>
+         <NameSpace name="defaultNamespace">
+            <Partition>*</Partition>
+         </NameSpace>
+            <Policy alignee="Initial"
+                    aligner="true"
+                    durability="Durable"
+                    masterPriority="${OSPL_MASTER_PRIORITY:-1}"
+                    nameSpace="defaultNamespace"/>
+      </NameSpaces>
+   </DurabilityService>
+   <TunerService name="cmsoap">
+      <Server>
+         <PortNr>50000</PortNr>
+      </Server>
+   </TunerService>
+</OpenSplice>


### PR DESCRIPTION
Update ncsa deployment to use new environment variable LSST_DDS_PARTITION_PREFIX and remove the deprecated LSST_DDS_DOMAIN.
Make build cycle a variable in the .env file.
Only add ScriptQueue and Watcher to LOVE.
Use an external bridge network created in the host.
Add deployment at NCSA.