### PR TITLE
Add write permission to jupyter container for development

### DIFF
--- a/deploy/local/live/docker-compose.yml
+++ b/deploy/local/live/docker-compose.yml
@@ -208,6 +208,7 @@ services:
       dockerfile: Dockerfile-jupyter
       args:
         LSSTTS_DEV_VERSION: "${LSSTTS_DEV_VERSION}"
+    user: root
     environment:
       - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
       - JUPYTER_PASS=${JUPYTER_PASS}

--- a/jupyter/love.ipynb
+++ b/jupyter/love.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lsst.ts import salobj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "love_csc = salobj.Controller(\"LOVE\", index=None, do_callbacks=False)\n",
+    "await love_csc.start_task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "love_csc.evt_observingLog.set(user=\"User\", message=\"Log message\")\n",
+    "love_csc.evt_observingLog.put()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds the user: root argument to the docker-compose file for development. Before this changes files couldn't be created by the jupyter lab gui neither from the command line of the container, now files can be modified and created.