### PR TITLE
Add comment that indicates how to use styleguide

### DIFF
--- a/deploy/local/lite/nginx.conf
+++ b/deploy/local/lite/nginx.conf
@@ -18,8 +18,10 @@ server {
         proxy_redirect off;
     }
 
+    # There a is a bug accesing styleguide through localhost/styleguide
+    # try localhost:3001 instead
     location /styleguide {
-        proxy_pass http://frontend:3001;
+        proxy_pass http://styleguide:3001;
     }
 
     location /manager {

--- a/deploy/local/live-csc/nginx.conf
+++ b/deploy/local/live-csc/nginx.conf
@@ -14,6 +14,8 @@ server {
         proxy_redirect off;
     }
 
+    # There a is a bug accesing styleguide through localhost/styleguide
+    # try localhost:3001 instead
     location /styleguide {
         proxy_pass http://love-styleguide-mount:3001;
     }

--- a/deploy/local/live-csc/nginx.conf
+++ b/deploy/local/live-csc/nginx.conf
@@ -14,9 +14,9 @@ server {
         proxy_redirect off;
     }
 
-    # location /styleguide {
-    #     proxy_pass http://love-styleguide-mount:3001;
-    # }
+    location /styleguide {
+        proxy_pass http://love-styleguide-mount:3001;
+    }
 
     location /gencam {
         proxy_pass http://gencam-sim:5013;

--- a/deploy/local/live/nginx.conf
+++ b/deploy/local/live/nginx.conf
@@ -14,9 +14,11 @@ server {
         proxy_redirect off;
     }
 
-    # location /styleguide {
-    #     proxy_pass http://love-styleguide-mount:3001;
-    # }
+    # There a is a bug accesing styleguide through localhost/styleguide
+    # try localhost:3001 instead
+    location /styleguide {
+        proxy_pass http://love-styleguide-mount:3001;
+    }
 
     location /gencam {
         proxy_pass http://gencam-sim:5013;


### PR DESCRIPTION
This PR set a comment that gives instructions about how to enable styleguide. This instructions were added to: **lite**, **live** and **live-csc** environments