### PR TITLE
Remove temporary SALSubsystems XML

### DIFF
--- a/deploy/local/live-csc/.env
+++ b/deploy/local/live-csc/.env
@@ -49,6 +49,3 @@ TS_EXTERNALSCRIPTS=../../../../ts_externalscripts/scripts
 
 # lsstts/develop-env version
 LSSTTS_DEV_VERSION=c0018.000
-
-# TEMPORARY SALSUBSYSTEMS FILE PATH
-SALSUBSYSTEMS_XML_PATH=../../SALSubsystems.xml

--- a/deploy/local/live-csc/docker-compose.yml
+++ b/deploy/local/live-csc/docker-compose.yml
@@ -26,7 +26,6 @@ x-base-producer: &base-producer
   volumes:
     - ${DOCKERFILE_PATH_PRODUCER}:/usr/src/love
     - ./config:/usr/src/love/producer/config/
-    - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
   logging:
     driver: "json-file"
     options:
@@ -136,7 +135,6 @@ services:
     restart: always
     volumes:
       - ./config:/home/saluser/config/
-      - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
     logging:
       driver: "json-file"
       options:
@@ -159,7 +157,6 @@ services:
     volumes:
       - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
       - ./config:/home/saluser/config/
-      - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
     logging:
       driver: "json-file"
       options:
@@ -180,7 +177,6 @@ services:
     volumes:
       - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
       - ./config:/home/saluser/config/
-      - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
     entrypoint: ["/home/saluser/atmcs-setup.sh"]
     logging:
       driver: "json-file"
@@ -203,7 +199,6 @@ services:
       - ./config:/home/saluser/config/
       - ${TS_STANDARDSCRIPTS}:/home/saluser/repos/ts_scriptqueue/tests/data/standard/
       - ${TS_EXTERNALSCRIPTS}:/home/saluser/repos/ts_scriptqueue/tests/data/external/
-      - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
     logging:
       driver: "json-file"
       options:
@@ -226,7 +221,6 @@ services:
     volumes:
       - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
       - ./config:/home/saluser/config/
-      - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
     logging:
       driver: "json-file"
       options:
@@ -244,7 +238,6 @@ services:
     volumes:
       - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
       - ${DOCKERFILE_PATH_SIMULATOR}/simulator/gencam/simulatorcamera.py:/home/saluser/repos/ts_GenericCamera/python/lsst/ts/GenericCamera/driver/simulatorcamera.py
-      - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
     logging:
       driver: "json-file"
       options:
@@ -269,7 +262,6 @@ services:
     volumes:
       - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
       - ./config:/home/saluser/config/
-      - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
     logging:
       driver: "json-file"
       options:
@@ -319,7 +311,6 @@ services:
         max-size: "10m"
     volumes:
       - ${JUPYTER_PATH}:/home/saluser/notebooks
-      - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
     ports:
       - 1234:1234
 
@@ -338,7 +329,6 @@ services:
     restart: always
     volumes:
       - ${DOCKERFILE_PATH_COMMANDER}:/usr/src/love
-      - ${SALSUBSYSTEMS_XML_PATH}:/home/saluser/repos/ts_xml/sal_interfaces/SALSubsystems.xml
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
This PR makes missing removes of the SALSubsystems XML volumes on the **live-csc** environment