### PR TITLE
Upgrade develop-env to c0018.001

### DIFF
--- a/deploy/local/live-csc/.env
+++ b/deploy/local/live-csc/.env
@@ -48,4 +48,4 @@ TS_STANDARDSCRIPTS=../../../../ts_standardscripts/scripts
 TS_EXTERNALSCRIPTS=../../../../ts_externalscripts/scripts
 
 # lsstts/develop-env version
-dev_cycle=c0017.000
+dev_cycle=c0018.001

--- a/deploy/local/live/.env
+++ b/deploy/local/live/.env
@@ -48,4 +48,4 @@ TS_STANDARDSCRIPTS=../../../../ts_standardscripts/scripts
 TS_EXTERNALSCRIPTS=../../../../ts_externalscripts/scripts
 
 # lsstts/develop-env version
-dev_cycle=c0017.000
+dev_cycle=c0018.001


### PR DESCRIPTION
This PR update `.env` file of the local live environments, changing `dev_cycle` from `c0017.000` to `c0018.001`