### PR TITLE
Add environment variable to control which version of the producer is used on LOVE-manager

### DIFF
--- a/deploy/local/live-csc/docker-compose.yml
+++ b/deploy/local/live-csc/docker-compose.yml
@@ -331,6 +331,7 @@ services:
       - DB_PORT=${DB_PORT}
       - COMMANDER_HOSTNAME=love-commander-mount
       - COMMANDER_PORT=5000
+      - LOVE_CSC_PRODUCER=True
     network_mode: ${NETWORK_NAME}
     ports:
       - "8000:8000"


### PR DESCRIPTION
This PR is a small hotfix that enables backwards compatibility of the LOVE-manager container respecting to the LOVE-producer version that is being used