### PR TITLE
Add new simulators to live-csc

### DIFF
--- a/deploy/local/live-csc/docker-compose.yml
+++ b/deploy/local/live-csc/docker-compose.yml
@@ -124,6 +124,28 @@ services:
         max-file: "5"
         max-size: "10m"
 
+  mtcs-sim:
+    build:
+      context: ${DOCKERFILE_PATH_SIMULATOR}
+      dockerfile: Dockerfile-mtcs
+      args:
+        dev_cycle: "${dev_cycle}"
+    container_name: mtcs-sim-build
+    entrypoint: ["/home/saluser/mtcs-setup.sh"]
+    environment:
+      - OSPL_URI=${OSPL_URI}
+      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
+    network_mode: ${NETWORK_NAME}
+    restart: always
+    volumes:
+      - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
+      - ./config:/home/saluser/config/
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
+
   scriptqueue-sim:
     build:
       context: ${DOCKERFILE_PATH_SIMULATOR}

--- a/deploy/local/live-csc/docker-compose.yml
+++ b/deploy/local/live-csc/docker-compose.yml
@@ -102,14 +102,14 @@ services:
       LOVE_CSC_PRODUCER: WeatherStation:1
 
   # -------------- simulators --------------
-  atdome-sim:
+  atcs-sim:
     build:
       context: ${DOCKERFILE_PATH_SIMULATOR}
-      dockerfile: Dockerfile-atdome
+      dockerfile: Dockerfile-atcs
       args:
         dev_cycle: "${dev_cycle}"
-    container_name: atdome-sim-build
-    entrypoint: ["/home/saluser/atdome-setup.sh"]
+    container_name: atcs-sim-build
+    entrypoint: ["/home/saluser/atcs-setup.sh"]
     environment:
       - OSPL_URI=${OSPL_URI}
       - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
@@ -118,27 +118,6 @@ services:
     volumes:
       - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
       - ./config:/home/saluser/config/
-    logging:
-      driver: "json-file"
-      options:
-        max-file: "5"
-        max-size: "10m"
-
-  atmcs-sim:
-    build:
-      context: ${DOCKERFILE_PATH_SIMULATOR}
-      dockerfile: Dockerfile-atmcs
-      args:
-        dev_cycle: "${dev_cycle}"
-    container_name: atmcs-sim-build
-    environment:
-      - OSPL_URI=${OSPL_URI}
-      - LSST_DDS_DOMAIN=${LSST_DDS_DOMAIN}
-    network_mode: ${NETWORK_NAME}
-    volumes:
-      - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
-      - ./config:/home/saluser/config/
-    entrypoint: ["/home/saluser/atmcs-setup.sh"]
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
This PR adds new simulator images to be run on the simulated environments. The new simulators are:

- ATCS
- MTCS