### PR TITLE
Fix changeset of linode deploy step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
           changeset "deploy/linode/docker-compose.yml"
           changeset "deploy/linode/nginx-develop.conf"
           changeset "deploy/linode/run.sh"
-          changeset "jupyter"
+          changeset "jupyter/*"
           changeset "Jenkinsfile"
           triggeredBy "UpstreamCause"
           triggeredBy "UserIdCause"


### PR DESCRIPTION
This PR makes a small change to run the linode deploy step of the Jenkins pipeline when making changes on jupyter notebook files at the `jupyer/` folder