### PR TITLE
Upgrade dev-cycle to c0021.007

### DIFF
--- a/deploy/local/live-csc/.env
+++ b/deploy/local/live-csc/.env
@@ -48,4 +48,4 @@ TS_STANDARDSCRIPTS=../../../../ts_standardscripts/scripts
 TS_EXTERNALSCRIPTS=../../../../ts_externalscripts/scripts
 
 # lsstts/develop-env version
-dev_cycle=c0020.006
+dev_cycle=c0021.007


### PR DESCRIPTION
This PR make some changes to be compliant with the docker image `lsstts/develop-env` version `c0021.007`