### PR TITLE
Hotfix: static files on production environments

### DIFF
--- a/deploy/linode/docker-compose-master.yml
+++ b/deploy/linode/docker-compose-master.yml
@@ -302,6 +302,7 @@ services:
     volumes:
       - ./config:/usr/src/love/manager/config
       - ./media:/usr/src/love/manager/media
+      - manager-static:/usr/src/love/manager/static
     logging:
       driver: "json-file"
       options:
@@ -336,6 +337,7 @@ services:
       - ./nginx-master.conf:/etc/nginx/conf.d/default.conf
       - frontend-volume:/usr/src/love-frontend
       - ./media:/usr/src/love-manager/media
+      - manager-static:/usr/src/love-manager/static
     logging:
       driver: "json-file"
       options:
@@ -344,3 +346,4 @@ services:
 
 volumes:
   frontend-volume:
+  manager-static:

--- a/deploy/linode/docker-compose.yml
+++ b/deploy/linode/docker-compose.yml
@@ -302,6 +302,7 @@ services:
     volumes:
       - ./config:/usr/src/love/manager/config
       - ./media:/usr/src/love/manager/media
+      - manager-static:/usr/src/love/manager/static
     logging:
       driver: "json-file"
       options:
@@ -336,6 +337,7 @@ services:
       - ./nginx-develop.conf:/etc/nginx/conf.d/default.conf
       - frontend-volume:/usr/src/love-frontend
       - ./media:/usr/src/love-manager/media
+      - manager-static:/usr/src/love-manager/static
     logging:
       driver: "json-file"
       options:
@@ -344,3 +346,4 @@ services:
 
 volumes:
   frontend-volume:
+  manager-static:

--- a/deploy/linode/nginx-develop.conf
+++ b/deploy/linode/nginx-develop.conf
@@ -23,6 +23,10 @@ server {
     location /manager/media {
         alias /usr/src/love-manager/media;
     }
+
+    location /manager/static {
+        alias /usr/src/love-manager/static;
+    }
     
     #location /gencam {
     #    proxy_pass http://gencam-sim:5013;

--- a/deploy/linode/nginx-master.conf
+++ b/deploy/linode/nginx-master.conf
@@ -23,6 +23,10 @@ server {
     location /manager/media {
         alias /usr/src/love-manager/media;
     }
+
+    location /manager/static {
+        alias /usr/src/love-manager/static;
+    }
     
     #location /gencam {
     #    proxy_pass http://gencam-sim:5013;

--- a/deploy/ncsa/docker-compose.yml
+++ b/deploy/ncsa/docker-compose.yml
@@ -44,6 +44,7 @@ x-manager-service: &manager-service
   volumes:
     - ./config:/usr/src/love/manager/config
     - ./media:/usr/src/love/manager/media 
+    - manager-static:/usr/src/love/manager/static
 
 x-base-producer-env: &base-producer-environment
   LSST_DDS_PARTITION_PREFIX: ${LSST_DDS_PARTITION_PREFIX}
@@ -466,9 +467,11 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
       - frontend-volume:/usr/src/love-frontend
       - ./media:/usr/src/love-manager/media
+      - manager-static:/usr/src/love-manager/static
 
 volumes:
   frontend-volume:
+  manager-static:
 
 networks:
   default:

--- a/deploy/ncsa/nginx.conf
+++ b/deploy/ncsa/nginx.conf
@@ -96,4 +96,8 @@ server {
         alias /usr/src/love-manager/media;
     }
 
+    location /manager/static {
+        alias /usr/src/love-manager/static;
+    }
+
 }

--- a/deploy/summit/docker-compose.yml
+++ b/deploy/summit/docker-compose.yml
@@ -43,6 +43,7 @@ x-manager-service: &manager-service
   volumes:
     - ./config:/usr/src/love/manager/config
     - ./media:/usr/src/love/manager/media 
+    - manager-static:/usr/src/love/manager/static
     
 x-base-producer-env: &base-producer-environment
   LSST_DDS_PARTITION_PREFIX: ${LSST_DDS_PARTITION_PREFIX}
@@ -471,6 +472,8 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
       - frontend-volume:/usr/src/love-frontend
       - ./media:/usr/src/love-manager/media
+      - manager-static:/usr/src/love-manager/static
 
 volumes:
   frontend-volume:
+  manager-static:

--- a/deploy/summit/nginx.conf
+++ b/deploy/summit/nginx.conf
@@ -96,4 +96,8 @@ server {
         alias /usr/src/love-manager/media;
     }
 
+    location /manager/static {
+        alias /usr/src/love-manager/static;
+    }
+
 }

--- a/deploy/summit2/docker-compose.yml
+++ b/deploy/summit2/docker-compose.yml
@@ -406,6 +406,7 @@ services:
     volumes:
       - ./config:/usr/src/love/manager/config
       - ./media:/usr/src/love/manager/media
+      - manager-static:/usr/src/love/manager/static
 
   manager_atqueue:
     <<: *service
@@ -635,6 +636,8 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
       - frontend-volume:/usr/src/love-frontend
       - ./media:/usr/src/love-manager/media
+      - manager-static:/usr/src/love-manager/static
 
 volumes:
   frontend-volume:
+  manager-static:

--- a/deploy/summit2/nginx.conf
+++ b/deploy/summit2/nginx.conf
@@ -77,4 +77,8 @@ server {
     location /manager/media {
         alias /usr/src/love-manager/media;
     }
+
+    location /manager/static {
+        alias /usr/src/love-manager/static;
+    }
 }

--- a/deploy/tucson/docker-compose.yml
+++ b/deploy/tucson/docker-compose.yml
@@ -90,6 +90,8 @@ services:
     volumes:
       - ./config:/usr/src/love/manager/config
       - ./media:/usr/src/love/manager/media
+      - manager-static:/usr/src/love/manager/static
+
     logging:
       driver: "json-file"
       options:
@@ -126,6 +128,7 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
       - frontend-volume:/usr/src/love-frontend
       - ./media:/usr/src/love-manager/media
+      - manager-static:/usr/src/love-manager/static
     logging:
       driver: "json-file"
       options:
@@ -134,6 +137,7 @@ services:
 
 volumes:
   frontend-volume:
+  manager-static:
 
 networks:
   default:

--- a/deploy/tucson/nginx.conf
+++ b/deploy/tucson/nginx.conf
@@ -23,4 +23,8 @@ server {
     location /manager/media {
         alias /usr/src/love-manager/media;
     }
+
+    location /manager/static {
+        alias /usr/src/love-manager/static;
+    }
 }


### PR DESCRIPTION
On PR #126 we removed references to the `manager-static` volume. This change was introduced because saw that on our local development environments it was not neccessary to add that volume, however we realized that on productions environments it was neccessay to include the `manager-static` volume in order that nginx is able to access the static files. Thus this PR makes a hotfix on the production environments.