### PR TITLE
Fix LOVE-manager static folder reference

### DIFF
--- a/deploy/tucson/docker-compose.yml
+++ b/deploy/tucson/docker-compose.yml
@@ -34,7 +34,7 @@ x-manager-service: &manager-service
     - COMMANDER_PORT=5000
     - LOVE_CSC_PRODUCER=${LOVE_CSC_PRODUCER}
   volumes:
-    - manager-static:/usr/src/love/manager
+    - manager-static:/usr/src/love/manager/static
     - ./config:/usr/src/love/manager/config
     - ./media:/usr/src/love/manager/media
 


### PR DESCRIPTION
This PR makes a small adjustment to correctly reference the static folder of the LOVE-manager software, which is used by the nginx service