### PR TITLE
Update dependencies

### DIFF
--- a/docsrc/requirements.txt
+++ b/docsrc/requirements.txt
@@ -6,14 +6,14 @@ docutils==0.15.2
 idna==2.8
 imagesize==1.1.0
 Jinja2==2.11.3
-m2r==0.2.1
+m2r<2.0.0
 MarkupSafe==1.1.1
 mistune==0.8.4
 packaging==19.1
 Pygments==2.7.4
 pyparsing==2.4.2
 pytz==2019.2
-requests==2.22.0
+requests==2.28.1
 six==1.12.0
 snowballstemmer==1.9.0
 Sphinx==2.2.0


### PR DESCRIPTION
This PR updates `requirements.txt` `mistune` and `requests`packages to avoid errors with `m2r` when using `mistune >= 2.0.0`