### PR TITLE
Add manager-tasks container

### DIFF
--- a/deploy/local/live-csc/docker-compose.yml
+++ b/deploy/local/live-csc/docker-compose.yml
@@ -241,27 +241,27 @@ services:
         max-file: "5"
         max-size: "10m"
 
-  # weatherstation-sim:
-  #  build:
-  #    context: ${DOCKERFILE_PATH_SIMULATOR}
-  #    dockerfile: docker/Dockerfile-weatherstation
-  #    args:
-  #      dev_cycle: "${dev_cycle}"
-  #  container_name: weatherstation-sim-build
-  #  entrypoint: ["/home/saluser/weatherstation-setup.sh"]
-  #  environment:
-  #    - OSPL_URI=${OSPL_URI}
-  #    - LSST_DDS_PARTITION_PREFIX=${LSST_DDS_PARTITION_PREFIX}
-  #  network_mode: ${NETWORK_NAME}
-  #  restart: always
-  #  volumes:
-  #    - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
-  #    - ./config:/home/saluser/config/
-  #  logging:
-  #    driver: "json-file"
-  #    options:
-  #      max-file: "5"
-  #      max-size: "10m"
+  weatherstation-sim:
+   build:
+     context: ${DOCKERFILE_PATH_SIMULATOR}
+     dockerfile: docker/Dockerfile-weatherstation
+     args:
+       dev_cycle: "${dev_cycle}"
+   container_name: weatherstation-sim-build
+   entrypoint: ["/home/saluser/weatherstation-setup.sh"]
+   environment:
+     - OSPL_URI=${OSPL_URI}
+     - LSST_DDS_PARTITION_PREFIX=${LSST_DDS_PARTITION_PREFIX}
+   network_mode: ${NETWORK_NAME}
+   restart: always
+   volumes:
+     - ${OSPL_CONFIG_PATH}:${OSPL_MOUNT_POINT}
+     - ./config:/home/saluser/config/
+   logging:
+     driver: "json-file"
+     options:
+       max-file: "5"
+       max-size: "10m"
 
   # TODO: we should use a public image
   # gencam-sim:
@@ -397,6 +397,35 @@ services:
       - ${DOCKERFILE_PATH_MANAGER}:/usr/src/love
       - ./config:/usr/src/love/manager/config
       - ./media:/usr/src/love/manager/media
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: "10m"
+
+  manager-tasks:
+    container_name: love-manager-tasks-mount
+    build:
+      context: ${DOCKERFILE_PATH_MANAGER}
+      dockerfile: docker/Dockerfile-tasks
+    image: love-manager-tasks-image-mount
+    depends_on:
+      - database
+    environment:
+      - PROCESS_CONNECTION_PASS=${PROCESS_CONNECTION_PASS}
+      - SECRET_KEY=${MANAGER_SECRET_KEY}
+      - DB_ENGINE=${DB_ENGINE}
+      - DB_NAME=${DB_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASS=${DB_PASS}
+      - DB_HOST=${DB_HOST}
+      - DB_PORT=${DB_PORT}
+      - COMMANDER_HOSTNAME=love-commander-mount
+      - COMMANDER_PORT=5000
+    network_mode: ${NETWORK_NAME}
+    restart: always
+    volumes:
+      - ${DOCKERFILE_PATH_MANAGER}:/usr/src/love
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
This PR adds a new container that will contain the daemon used for background tasks (https://django-background-tasks.readthedocs.io/en/latest/). This daemon will be used to implement the Authlist _Time Limited Access Restriction Sequence_ explained in the attached document: [LOVEauthList_reqs_(final-v).docx](https://github.com/lsst-ts/LOVE-integration-tools/files/9427471/LOVEauthList_reqs_.final-v.docx)
