### PR TITLE
Fix ScriptQueue simulator

### DIFF
--- a/deploy/local/live-csc/.env
+++ b/deploy/local/live-csc/.env
@@ -60,8 +60,8 @@ OSPL_URI=file:///home/saluser/ospl.xml
 LSST_EFD_HOST=139.229.162.118
 
 # ts_scripts required for scriptqueue-sim
-TS_STANDARDSCRIPTS=../../../../ts_standardscripts/scripts
-TS_EXTERNALSCRIPTS=../../../../ts_externalscripts/scripts
+TS_STANDARDSCRIPTS=../../../../ts_standardscripts/python/lsst/ts/standardscripts/
+TS_EXTERNALSCRIPTS=../../../../ts_externalscripts/python/lsst/ts/externalscripts/
 
 # lsstts/develop-env version
 dev_cycle=develop


### PR DESCRIPTION
This PR adjusts the `ts_standardscripts` and `ts_externalscripts` paths as the ScriptQueue simulator stopped working. This PR is related to https://github.com/lsst-ts/LOVE-simulator/pull/62.