### PR TITLE
Add LOVE producer for WeatherForecast CSC

### DIFF
--- a/deploy/summit2/.env
+++ b/deploy/summit2/.env
@@ -17,6 +17,7 @@ LOVE_PRODUCER_WEBSOCKET_HOST_MTScheduler=love-nginx/manager/obssys/ws/subscripti
 LOVE_PRODUCER_WEBSOCKET_HOST_PMD=love-nginx/manager/obssys/ws/subscription
 LOVE_PRODUCER_WEBSOCKET_HOST_Watcher=love-nginx/manager/obssys/ws/subscription
 LOVE_PRODUCER_WEBSOCKET_HOST_WeatherStation1=love-nginx/manager/obssys/ws/subscription
+LOVE_PRODUCER_WEBSOCKET_HOST_WeatherForecast=love-nginx/manager/obssys/ws/subscription
 
 # Auxtel Manager
 LOVE_PRODUCER_WEBSOCKET_HOST_ATAOS=love-nginx/manager/auxtel/ws/subscription

--- a/deploy/summit2/docker-compose.yml
+++ b/deploy/summit2/docker-compose.yml
@@ -343,6 +343,13 @@ services:
       <<: *base-producer-environment
       WEBSOCKET_HOST: ${LOVE_PRODUCER_WEBSOCKET_HOST_WeatherStation1}
       LOVE_CSC_PRODUCER: WeatherStation:1
+  weatherforecast:
+    <<: *base-producer
+    container_name: producer-weatherforecast
+    environment:
+      <<: *base-producer-environment
+      WEBSOCKET_HOST: ${LOVE_PRODUCER_WEBSOCKET_HOST_WeatherForecast}
+      LOVE_CSC_PRODUCER: WeatherForecast:0
 
   #-----LOVE COMMANDER -----------
   commander:

--- a/deploy/tucson/.env
+++ b/deploy/tucson/.env
@@ -59,6 +59,7 @@ LOVE_PRODUCER_WEBSOCKET_HOST_DIMM2=love-nginx/manager/eas/ws/subscription
 LOVE_PRODUCER_WEBSOCKET_HOST_DSM1=love-nginx/manager/eas/ws/subscription
 LOVE_PRODUCER_WEBSOCKET_HOST_DSM2=love-nginx/manager/eas/ws/subscription
 LOVE_PRODUCER_WEBSOCKET_HOST_WeatherStation1=love-nginx/manager/eas/ws/subscription
+LOVE_PRODUCER_WEBSOCKET_HOST_WeatherForecast=love-nginx/manager/eas/ws/subscription
 
 # GenericCamera
 LOVE_PRODUCER_WEBSOCKET_HOST_GENERICCAMERA1=love-nginx/manager/gc/ws/subscription

--- a/deploy/tucson/docker-compose.yml
+++ b/deploy/tucson/docker-compose.yml
@@ -387,6 +387,13 @@ services:
       <<: *base-producer-environment
       WEBSOCKET_HOST: ${LOVE_PRODUCER_WEBSOCKET_HOST_WeatherStation1}
       LOVE_CSC_PRODUCER: WeatherStation:1
+  weatherforecast:
+    <<: *base-producer
+    container_name: producer-weatherforecast
+    environment:
+      <<: *base-producer-environment
+      WEBSOCKET_HOST: ${LOVE_PRODUCER_WEBSOCKET_HOST_WeatherForecast}
+      LOVE_CSC_PRODUCER: WeatherForecast:0
 
   #-----LOVE COMMANDER -----------
   commander:


### PR DESCRIPTION
This PR adds configurations to deploy a LOVE producer for the `WeatherForecast:0` CSC on two deployments:

- summit2
- tucson (bare metal machine)