### PR TITLE
Update ScriptQueue configurations for linode deployment

### DIFF
--- a/deploy/linode/.env
+++ b/deploy/linode/.env
@@ -38,5 +38,5 @@ LSST_EFD_HOST=139.229.162.118
 
 
 # ts_scripts required for scriptqueue-sim
-TS_STANDARDSCRIPTS=./ts_standardscripts/scripts
-TS_EXTERNALSCRIPTS=./ts_externalscripts/scripts
+TS_STANDARDSCRIPTS=./ts_standardscripts/python/lsst/ts/standardscripts/
+TS_EXTERNALSCRIPTS=./ts_externalscripts/python/lsst/ts/externalscripts/

--- a/deploy/linode/docker-compose.yml
+++ b/deploy/linode/docker-compose.yml
@@ -113,7 +113,7 @@ services:
     volumes:
       - ./config:/home/saluser/config/
       - ${TS_STANDARDSCRIPTS}:/home/saluser/repos/ts_scriptqueue/tests/data/standard/
-      - ./scripts:/home/saluser/repos/ts_scriptqueue/tests/data/external/
+      - ${TS_EXTERNALSCRIPTS}:/home/saluser/repos/ts_scriptqueue/tests/data/external/
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
This PR makes some updates to the Scriptqueue Simulator. The `ts_standardscripts` and `ts_externalscripts` have a new structure which now is considered.