### PR TITLE
Extend redis configuration to flush idle clients

### DIFF
--- a/deploy/local/live-csc/docker-compose.yml
+++ b/deploy/local/live-csc/docker-compose.yml
@@ -381,11 +381,13 @@ services:
   redis:
     container_name: redis
     image: redis:5.0.3
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASS}
+    command: redis-server /data/redis.conf --appendonly yes --requirepass ${REDIS_PASS}
     network_mode: ${NETWORK_NAME}
     ports:
       - "6379:6379"
     restart: always
+    volumes:
+      - ./redis.conf:/data/redis.conf
     logging:
       driver: "json-file"
       options:

--- a/deploy/local/live-csc/redis.conf
+++ b/deploy/local/live-csc/redis.conf
@@ -1,0 +1,1 @@
+timeout 60

--- a/deploy/summit/docker-compose.yml
+++ b/deploy/summit/docker-compose.yml
@@ -557,9 +557,11 @@ services:
     <<: *service
     container_name: redis
     image: redis:5.0.3
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASS}
+    command: redis-server /data/redis.conf --appendonly yes --requirepass ${REDIS_PASS}
     ports:
       - "6379:6379"
+    volumes:
+      - ./redis.conf:/data/redis.conf
 
   database:
     <<: *service

--- a/deploy/summit/redis.conf
+++ b/deploy/summit/redis.conf
@@ -1,0 +1,1 @@
+timeout 60

--- a/deploy/summit2/docker-compose.yml
+++ b/deploy/summit2/docker-compose.yml
@@ -428,9 +428,11 @@ services:
     <<: *service
     container_name: redis
     image: redis:5.0.3
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASS}
+    command: redis-server /data/redis.conf --appendonly yes --requirepass ${REDIS_PASS}
     ports:
       - "6379:6379"
+    volumes:
+      - ./redis.conf:/data/redis.conf
 
   database:
     <<: *service

--- a/deploy/summit2/redis.conf
+++ b/deploy/summit2/redis.conf
@@ -1,0 +1,1 @@
+timeout 60

--- a/deploy/tucson/docker-compose.yml
+++ b/deploy/tucson/docker-compose.yml
@@ -505,12 +505,14 @@ services:
     <<: *service
     container_name: redis
     image: redis:5.0.3
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASS}
+    command: redis-server /data/redis.conf --appendonly yes --requirepass ${REDIS_PASS}
     # networks:
     #   - dds-network
     # network_mode: host
     ports:
       - "6379:6379"
+    volumes:
+      - ./redis.conf:/data/redis.conf
 
   database:
     <<: *service

--- a/deploy/tucson/redis.conf
+++ b/deploy/tucson/redis.conf
@@ -1,0 +1,1 @@
+timeout 60


### PR DESCRIPTION
This PR extends the `docker-compose.yml` redis instructions to include a custom `redis.conf` file. This way custom configurations can be input to the `redis-server` service. In this case the `timeout 60` configuration was added in order to flush idle clients, preventing disconnections due to errors about maximum number of clients reached. The system is currently creating connections each time a user or producer connects, but they are not being deleted after it disconnects, thus this change will help in cleaning the redis cache.