### PR TITLE
Update nginx, redis and postgres images

### DIFF
--- a/deploy/base/docker-compose.yml
+++ b/deploy/base/docker-compose.yml
@@ -471,12 +471,14 @@ services:
     <<: *service
     container_name: redis
     image: redis:7
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASS}
+    command: redis-server /data/redis.conf --appendonly yes --requirepass ${REDIS_PASS}
     # networks:
     #   - dds-network
     # network_mode: host
     ports:
       - "6379:6379"
+    volumes:
+      - ./redis.conf:/data/redis.conf
 
   database:
     <<: *service

--- a/deploy/base/docker-compose.yml
+++ b/deploy/base/docker-compose.yml
@@ -470,7 +470,7 @@ services:
   redis:
     <<: *service
     container_name: redis
-    image: redis:5.0.3
+    image: redis:7
     command: redis-server --appendonly yes --requirepass ${REDIS_PASS}
     # networks:
     #   - dds-network
@@ -481,7 +481,7 @@ services:
   database:
     <<: *service
     container_name: love-database
-    image: postgres:12.0
+    image: postgres:15.0
     environment:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=${DB_USER}
@@ -565,7 +565,7 @@ services:
   nginx:
     <<: *service
     container_name: love-nginx
-    image: nginx:1.13.1
+    image: nginx:1.25.1
     depends_on:
       - manager01
       - manager02

--- a/deploy/base/redis.conf
+++ b/deploy/base/redis.conf
@@ -1,0 +1,1 @@
+timeout 60

--- a/deploy/local/lite/docker-compose.yml
+++ b/deploy/local/lite/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   nginx:
     container_name: love-nginx-mount
-    image: nginx:1.13.1
+    image: nginx:1.25.1
     depends_on:
       - frontend
     network_mode: ${NETWORK_NAME}

--- a/deploy/local/live-csc/docker-compose.yml
+++ b/deploy/local/live-csc/docker-compose.yml
@@ -380,7 +380,7 @@ services:
 
   redis:
     container_name: redis
-    image: redis:5.0.3
+    image: redis:7
     command: redis-server /data/redis.conf --appendonly yes --requirepass ${REDIS_PASS}
     network_mode: ${NETWORK_NAME}
     ports:
@@ -396,7 +396,7 @@ services:
 
   database:
     container_name: love-database
-    image: postgres:12.0
+    image: postgres:15.0
     environment:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=${DB_USER}
@@ -467,7 +467,7 @@ services:
 
   nginx:
     container_name: love-nginx-mount
-    image: nginx:1.13.1
+    image: nginx:1.25.1
     depends_on:
       - frontend
       - manager01

--- a/deploy/summit/docker-compose.yml
+++ b/deploy/summit/docker-compose.yml
@@ -556,7 +556,7 @@ services:
   redis:
     <<: *service
     container_name: redis
-    image: redis:5.0.3
+    image: redis:7
     command: redis-server /data/redis.conf --appendonly yes --requirepass ${REDIS_PASS}
     ports:
       - "6379:6379"
@@ -566,7 +566,7 @@ services:
   database:
     <<: *service
     container_name: love-database
-    image: postgres:12.0
+    image: postgres:15.0
     environment:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=${DB_USER}
@@ -701,7 +701,7 @@ services:
   nginx:
     <<: *service
     container_name: love-nginx
-    image: nginx:1.13.1
+    image: nginx:1.25.1
     depends_on:
       - manager_01
       - manager_02

--- a/deploy/summit2/docker-compose.yml
+++ b/deploy/summit2/docker-compose.yml
@@ -427,7 +427,7 @@ services:
   redis:
     <<: *service
     container_name: redis
-    image: redis:5.0.3
+    image: redis:7
     command: redis-server /data/redis.conf --appendonly yes --requirepass ${REDIS_PASS}
     ports:
       - "6379:6379"
@@ -437,7 +437,7 @@ services:
   database:
     <<: *service
     container_name: love-database
-    image: postgres:12.0
+    image: postgres:15.0
     environment:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=${DB_USER}
@@ -511,7 +511,7 @@ services:
   nginx:
     <<: *service
     container_name: love-nginx
-    image: nginx:1.13.1
+    image: nginx:1.25.1
     depends_on:
       - manager01
       - manager02

--- a/deploy/tucson/docker-compose.yml
+++ b/deploy/tucson/docker-compose.yml
@@ -504,7 +504,7 @@ services:
   redis:
     <<: *service
     container_name: redis
-    image: redis:5.0.3
+    image: redis:7
     command: redis-server /data/redis.conf --appendonly yes --requirepass ${REDIS_PASS}
     # networks:
     #   - dds-network
@@ -517,7 +517,7 @@ services:
   database:
     <<: *service
     container_name: love-database
-    image: postgres:12.0
+    image: postgres:15.0
     environment:
       - POSTGRES_DB=${DB_NAME}
       - POSTGRES_USER=${DB_USER}
@@ -605,7 +605,7 @@ services:
   nginx:
     <<: *service
     container_name: love-nginx
-    image: nginx:1.13.1
+    image: nginx:1.25.1
     depends_on:
       - manager01
       - manager02


### PR DESCRIPTION
This PR update the versions of `nginx`, `redis` and `postgres` to their latest versions. The following deployments were updated:

- summit
- summit2
- tucson
- base
- local/live-csc
- local/lite (only ngnix)