### PR TITLE
Increase body size for nginx requests to 5MB

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,12 @@
 Version History
 ===============
 
+
+
 v5.4.2
 ------
 
+* Increase body size for nginx requests to 5MB `<https://github.com/lsst-ts/LOVE-integration-tools/pull/192>`_
 * Refactor LOVE stress test scripts url setting `<https://github.com/lsst-ts/LOVE-integration-tools/pull/190>`_
 * Add missing changelog checker action `<https://github.com/lsst-ts/LOVE-integration-tools/pull/189>`_
 * Add LOVE uptime tests notebook `<https://github.com/lsst-ts/LOVE-integration-tools/pull/188>`_

--- a/deploy/local/live-csc/nginx.conf
+++ b/deploy/local/live-csc/nginx.conf
@@ -12,6 +12,7 @@ server {
     }
 
     location /manager {
+        client_max_body_size 5M;
         proxy_pass http://manager_load_balancer;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
This PR sets a new nginx configuration on the `nginx.conf` file in order to allow user files uploads up to 5MB.